### PR TITLE
One Drive Enum Username Output

### DIFF
--- a/onedrive_enum.py
+++ b/onedrive_enum.py
@@ -410,7 +410,9 @@ class UrlChecker:
                 currenttime = str(int(time.time()))
                 self.validcount+=1
                 #You need to create a file for the output and then specify that file here
-                output_filename = "/root/Test/onedrive_user_enum/securit_users.txt"
+                currentdir = os.getcwd()
+                output_filename = currentdir + '/' + self.domain + ".txt"
+                print(output_filename)
                 with open (output_filename, "a") as output_file:
                   output_text = f'{username}@{self.domain}'
                   output_file.write(output_text + '\n')

--- a/onedrive_enum.py
+++ b/onedrive_enum.py
@@ -412,7 +412,6 @@ class UrlChecker:
                 #You need to create a file for the output and then specify that file here
                 currentdir = os.getcwd()
                 output_filename = currentdir + '/' + self.domain + ".txt"
-                print(output_filename)
                 with open (output_filename, "a") as output_file:
                   output_text = f'{username}@{self.domain}'
                   output_file.write(output_text + '\n')

--- a/onedrive_enum.py
+++ b/onedrive_enum.py
@@ -409,6 +409,11 @@ class UrlChecker:
             elif status_code in ['401', '403']:
                 currenttime = str(int(time.time()))
                 self.validcount+=1
+                #You need to create a file for the output and then specify that file here
+                output_filename = "/root/Test/onedrive_user_enum/securit_users.txt"
+                with open (output_filename, "a") as output_file:
+                  output_text = f'{username}@{self.domain}'
+                  output_file.write(output_text + '\n')
                 print(f'[-] [{status_code}] VALID USERNAME FOR {self.tenant_name},{self.domain} - {username}, username:{username}@{self.domain}')
                 reconstructed_email = username.replace("_",".") + "@" + self.domain
                 self.sql_insert_user(reconstructed_email, username, self.domain,self.tenant_name,currenttime,self.environment)
@@ -1066,8 +1071,6 @@ def main():
         else:
             print(f"ERROR: {playlist} does not exist.")
             exit()
-
-
 
 if __name__ == "__main__":
     main()

--- a/onedrive_enum.py
+++ b/onedrive_enum.py
@@ -398,7 +398,7 @@ class UrlChecker:
         requests.packages.urllib3.disable_warnings()
 
         #self.currentcount+=1
-
+        lock = threading.Lock()
         try:
             r = self.requests_retry_session().head(url, timeout=8.0)
             #print("Status code is: {}".format(r.status_code))
@@ -412,9 +412,10 @@ class UrlChecker:
                 #You need to create a file for the output and then specify that file here
                 currentdir = os.getcwd()
                 output_filename = currentdir + '/' + self.domain + ".txt"
-                with open (output_filename, "a") as output_file:
-                  output_text = f'{username}@{self.domain}'
-                  output_file.write(output_text + '\n')
+                with lock:
+                    with open (output_filename, "a") as output_file:
+                        output_text = f'{username}@{self.domain}'
+                        output_file.write(output_text + '\n')
                 print(f'[-] [{status_code}] VALID USERNAME FOR {self.tenant_name},{self.domain} - {username}, username:{username}@{self.domain}')
                 reconstructed_email = username.replace("_",".") + "@" + self.domain
                 self.sql_insert_user(reconstructed_email, username, self.domain,self.tenant_name,currenttime,self.environment)


### PR DESCRIPTION
I added in a few lines of code that create an output file for the users discovered based off of the domain that was input. I'm then writing the email addresses that are found to be valid to this file in real time. I was previously having trouble with the initial file creation from the main branch if the tool stopped execution or aborted early. If either of these conditions happened then the output file would not be created and grabbing the users was impossible. So I thought that writing them as they were found to a file created prior to execution would alleviate that problem. I've ran this on my own many times and it works consistently and would love to see this implemented to the main branch if it makes sense.