### PR TITLE
Fix escape character in regex for Python 3.12+

### DIFF
--- a/onedrive_enum.py
+++ b/onedrive_enum.py
@@ -646,7 +646,7 @@ def lookup_tenant(domain):
 
     try:
         r = requests.post(url, data=xml, headers=headers, timeout=8.0)
-        domain_extract = re.findall('<Domain>(.*?)<\/Domain>', r.content.decode('utf-8'))
+        domain_extract = re.findall('<Domain>(.*?)</Domain>', r.content.decode('utf-8'))
         tenant_extract = [i for i, x in enumerate(domain_extract) if ".onmicrosoft.com" in x and ".mail.onmicrosoft.com" not in x] # this line gets the matching list item numbers only
         if ( len(tenant_extract) > 0):
             print(f"\nTenants Identified:\n---------------------")


### PR DESCRIPTION
I get this message when I run the script using Python 3.12 or greater:

```
/Users/jwillis/Code/onedrive_user_enum/./onedrive_enum.py:649: SyntaxWarning: invalid escape sequence '\/'
  domain_extract = re.findall('<Domain>(.*?)<\/Domain>', r.content.decode('utf-8'))
```

I adjusted the code to fix the escape characters in that regular expression. The backslash doesn't need to be escaped there.